### PR TITLE
override background-color with color-main-background

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1,0 +1,1 @@
+.table-striped tbody > tr:nth-child(odd) > td, .table-striped tbody > tr:nth-child(odd) > th {background-color: var(--color-main-background); }

--- a/index.php
+++ b/index.php
@@ -6,6 +6,7 @@
 \OCP\Util::addScript('flowupload', 'ng-flow-standalone');
 \OCP\Util::addScript('flowupload', 'app');
 \OCP\Util::addStyle('flowupload', 'bootstrap-combined');
+\OCP\Util::addStyle('flowupload', 'style');
 
 $tpl = new OCP\Template("flowupload", "main", "user");
 $tpl->printPage();


### PR DESCRIPTION
Releated to this #41 

I have added a custom stylesheet to override background-color property for .table-striped using the variable --color-main-background.

### Dark theme
![dark-theme](https://user-images.githubusercontent.com/49342144/55723433-665bab80-5a09-11e9-8ea6-ee83c2d31bcc.png)

### High contrast
![hight-contrast](https://user-images.githubusercontent.com/49342144/55723461-72e00400-5a09-11e9-947b-f0b9c3163ada.png)
