### PR TITLE
Overall progress label

### DIFF
--- a/js/ng-flow-standalone.js
+++ b/js/ng-flow-standalone.js
@@ -639,6 +639,16 @@
     },
 
     /**
+     * Returns the count of all files
+     * @function
+     * @returns {number}
+     */
+    getFilesCount: function () {
+      var count = this.files.length;
+      return count;
+    },
+
+    /**
      * Returns the total size of all files in bytes.
      * @function
      * @returns {number}

--- a/js/ng-flow-standalone.js
+++ b/js/ng-flow-standalone.js
@@ -639,7 +639,7 @@
     },
 
     /**
-     * Returns the count of all files
+     * Returns the count of files in the queue
      * @function
      * @returns {number}
      */
@@ -976,6 +976,22 @@
       // We don't want to lose percentages when an upload is paused
       this._prevProgress = Math.max(this._prevProgress, percent > 0.9999 ? 1 : percent);
       return this._prevProgress;
+    },
+
+    /**
+     * Get current number of complete chunks
+     * @function
+     * @returns {number} from 0 to chunks.length
+     */
+    completeChunks: function () {
+      var completeChunks = 0;
+
+      each(this.chunks, function (c) {
+        if(c.progress() === 1){
+          completeChunks++;
+        }
+      });
+      return completeChunks;
     },
 
     /**

--- a/templates/main.php
+++ b/templates/main.php
@@ -17,6 +17,7 @@
     <a class="btn btn-small btn-danger" ng-click="$flow.pause()"><?= $l->t('Pause'); ?></a>
     <a class="btn btn-small btn-info" ng-click="$flow.cancel()"><?= $l->t('Cancel'); ?></a>
     <span class="label label-info"><?= $l->t('Size'); ?>: {{$flow.getSize() | bytes}}</span>
+    <span class="label label-info" ng-if="$flow.getFilesCount() != 0"><?= $l->t('Progress'); ?>: {{$flow.progress()*100 | number:2}}%</span>
     <span class="label label-info" ng-if="$flow.isUploading()"><?= $l->t('Uploading'); ?>...</span>
   </p>
   <table class="table table-hover table-bordered table-striped" flow-transfers>

--- a/templates/main.php
+++ b/templates/main.php
@@ -33,7 +33,7 @@
     <tr ng-repeat="file in transfers">
       <td>{{$index+1}}</td>
       <td title="UID: {{file.uniqueIdentifier}}">{{file.relativePath}}</td>
-      <td title="Chunks: {{file.chunks.length}}"><span ng-if="file.isUploading()">{{file.size*file.progress() | bytes}}/</span>{{file.size | bytes}}</td>
+      <td title="Chunks: {{file.completeChunks()}} / {{file.chunks.length}}"><span ng-if="file.isUploading()">{{file.size*file.progress() | bytes}}/</span>{{file.size | bytes}}</td>
       <td>
         <div class="btn-group" ng-if="!file.isComplete() || file.error">
           <progress max="1" value="{{file.progress()}}" title="{{file.progress()}}" ng-if="file.isUploading()" style="width:auto; height:auto; display:inline"></progress>


### PR DESCRIPTION
I think it would be cool to have a label that shows the overall progress of the flowupload upload. So i added it.
The flow object already has a progress function.
I just added a function to the flow object that returns the number of files being uploaded (including already finished files) to be able to hide the progress label if there are no files selected.
Its a really small change but i think its quite nice to have.
I often use flowupload to upload hundreds of Gigabyte and i dont want to scroll over the whole page to see the progress

![Screenshot_20190504_164534](https://user-images.githubusercontent.com/28999431/57180753-38dd1300-6e8c-11e9-9bb6-6e09f135f6f4.png)
