### PR TITLE
Feature to hide all finished uploads

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1,1 +1,12 @@
-.table-striped tbody > tr:nth-child(odd) > td, .table-striped tbody > tr:nth-child(odd) > th {background-color: var(--color-main-background); }
+.table-striped tbody > tr:nth-child(odd) > td, .table-striped tbody > tr:nth-child(odd) > th {
+  background-color: var(--color-main-background);
+}
+#hideFinishedCheckbox {
+  min-height: unset;
+  vertical-align: middle;
+  pointer-events: none;
+  margin: 0px;
+}
+#hideFinishedText{
+  vertical-align: middle;
+}

--- a/css/style.css
+++ b/css/style.css
@@ -1,3 +1,7 @@
+#app {
+  margin: 2em;
+  width:100%
+}
 .table-striped tbody > tr:nth-child(odd) > td, .table-striped tbody > tr:nth-child(odd) > th {
   background-color: var(--color-main-background);
 }
@@ -7,6 +11,6 @@
   pointer-events: none;
   margin: 0px;
 }
-#hideFinishedText{
+#hideFinishedText {
   vertical-align: middle;
 }

--- a/js/app.js
+++ b/js/app.js
@@ -35,6 +35,8 @@ app.controller('mainController', function($scope,$interval) {
   $scope.sortType     = 'relativePath';
   $scope.sortReverse  = false;
   
+  $scope.hideFinished  = false;
+  
   $scope.tableSortClicked = function(newSortType){
     if($scope.sortType === newSortType){
       $scope.sortReverse = !$scope.sortReverse;

--- a/l10n/de.js
+++ b/l10n/de.js
@@ -17,6 +17,7 @@ OC.L10N.register(
     "Resume" : "Fortsetzen",
     "Retry" : "Wiederholen",
     "Completed" : "Fertiggestellt",
-    "The files will be saved in your home directory." : "Die Dateien werden in Deinem Home-Verzeichnis gespeichert."
+    "The files will be saved in your home directory." : "Die Dateien werden in Deinem Home-Verzeichnis gespeichert.",
+    "Hide finished uploads": "Fertiggestelte Uploads ausblenden"
 },
 "nplurals=2; plural=(n != 1);");

--- a/l10n/de.json
+++ b/l10n/de.json
@@ -15,6 +15,7 @@
     "Resume" : "Fortsetzen",
     "Retry" : "Wiederholen",
     "Completed" : "Fertiggestellt",
-    "The files will be saved in your home directory." : "Die Dateien werden in Deinem Home-Verzeichnis gespeichert."
+    "The files will be saved in your home directory." : "Die Dateien werden in Deinem Home-Verzeichnis gespeichert.",
+    "Hide finished uploads": "Fertiggestelte Uploads ausblenden"
 },"pluralForm" :"nplurals=2; plural=(n != 1);"
 }

--- a/l10n/de_DE.js
+++ b/l10n/de_DE.js
@@ -17,6 +17,7 @@ OC.L10N.register(
     "Resume" : "Fortsetzen",
     "Retry" : "Wiederholen",
     "Completed" : "Fertiggestellt",
-    "The files will be saved in your home directory." : "Die Dateien werden in deinem Home-Verzeichnis gespeichert."
+    "The files will be saved in your home directory." : "Die Dateien werden in deinem Home-Verzeichnis gespeichert.",
+    "Hide finished uploads": "Fertiggestelte Uploads ausblenden"
 },
 "nplurals=2; plural=(n != 1);");

--- a/l10n/de_DE.json
+++ b/l10n/de_DE.json
@@ -15,6 +15,7 @@
     "Resume" : "Fortsetzen",
     "Retry" : "Wiederholen",
     "Completed" : "Fertiggestellt",
-    "The files will be saved in your home directory." : "Die Dateien werden in deinem Home-Verzeichnis gespeichert."
+    "The files will be saved in your home directory." : "Die Dateien werden in deinem Home-Verzeichnis gespeichert.",
+    "Hide finished uploads": "Fertiggestelte Uploads ausblenden"
 },"pluralForm" :"nplurals=2; plural=(n != 1);"
 }

--- a/templates/main.php
+++ b/templates/main.php
@@ -16,7 +16,7 @@
     <a class="btn btn-small btn-success" ng-click="$flow.resume()"><?= $l->t('Upload/Resume all'); ?></a>
     <a class="btn btn-small btn-danger" ng-click="$flow.pause()"><?= $l->t('Pause'); ?></a>
     <a class="btn btn-small btn-info" ng-click="$flow.cancel()"><?= $l->t('Cancel'); ?></a>
-    <a class="btn btn-small btn-info" ng-click="hideFinished = !hideFinished"><input style="min-height: unset; vertical-align: middle;" type="checkbox" ng-model="hideFinished"></input><span><?= $l->t('Hide finished uploads'); ?></span></a>
+    <a class="btn btn-small btn-info" ng-click="hideFinished = !hideFinished"><input style="min-height: unset; vertical-align: middle; pointer-events: none;" type="checkbox" ng-model="hideFinished"></input><span><?= $l->t('Hide finished uploads'); ?></span></a>
     <span class="label label-info"><?= $l->t('Size'); ?>: {{$flow.getSize() | bytes}}</span>
     <span class="label label-info" ng-if="$flow.getFilesCount() != 0"><?= $l->t('Progress'); ?>: {{$flow.progress()*100 | number:2}}%</span>
     <span class="label label-info" ng-if="$flow.isUploading()"><?= $l->t('Uploading'); ?>...</span>

--- a/templates/main.php
+++ b/templates/main.php
@@ -1,4 +1,4 @@
-<div ng-app="app" flow-init id="app" ng-controller="mainController" flow-prevent-drop ng-style="style" style="margin: 2em; width:100%">
+<div ng-app="app" flow-init id="app" ng-controller="mainController" flow-prevent-drop ng-style="style">
 
   <span class="btn" flow-btn><?= $l->t('Select File'); ?></span>
   <span class="btn" flow-btn flow-directory ng-show="$flow.supportDirectory"><?= $l->t('Select Folder'); ?></span>
@@ -54,7 +54,7 @@
       <td title="Chunks: {{file.completeChunks()}} / {{file.chunks.length}}"><span ng-if="file.isUploading()">{{file.size*file.progress() | bytes}}/</span>{{file.size | bytes}}</td>
       <td>
         <div class="btn-group" ng-if="!file.isComplete() || file.error">
-          <progress max="1" value="{{file.progress()}}" title="{{file.progress()}}" ng-if="file.isUploading()" style="width:auto; height:auto; display:inline"></progress>
+          <progress max="1" value="{{file.progress()}}" title="{{file.progress()}}" ng-if="file.isUploading()" style="width:auto; height:auto; display:inline;"></progress>
           <a class="btn btn-mini btn-warning" ng-click="file.pause()" ng-hide="file.paused">
             <?= htmlspecialchars($l->t('Pause')); ?>
           </a>

--- a/templates/main.php
+++ b/templates/main.php
@@ -16,7 +16,10 @@
     <a class="btn btn-small btn-success" ng-click="$flow.resume()"><?= $l->t('Upload/Resume all'); ?></a>
     <a class="btn btn-small btn-danger" ng-click="$flow.pause()"><?= $l->t('Pause'); ?></a>
     <a class="btn btn-small btn-info" ng-click="$flow.cancel()"><?= $l->t('Cancel'); ?></a>
-    <a class="btn btn-small btn-info" ng-click="hideFinished = !hideFinished"><input style="min-height: unset; vertical-align: middle; pointer-events: none;" type="checkbox" ng-model="hideFinished"></input><span><?= $l->t('Hide finished uploads'); ?></span></a>
+    <a class="btn btn-small btn-info" ng-click="hideFinished = !hideFinished">
+      <input id="hideFinishedCheckbox" type="checkbox" ng-model="hideFinished"></input>
+      <span id="hideFinishedText"><?= $l->t('Hide finished uploads'); ?></span>
+    </a>
     <span class="label label-info"><?= $l->t('Size'); ?>: {{$flow.getSize() | bytes}}</span>
     <span class="label label-info" ng-if="$flow.getFilesCount() != 0"><?= $l->t('Progress'); ?>: {{$flow.progress()*100 | number:2}}%</span>
     <span class="label label-info" ng-if="$flow.isUploading()"><?= $l->t('Uploading'); ?>...</span>
@@ -65,7 +68,7 @@
             <?= htmlspecialchars($l->t('Retry')); ?>
           </a>
         </div>
-	<span ng-if="file.isComplete() && !file.error"><?= htmlspecialchars($l->t('Completed')); ?></span>
+        <span ng-if="file.isComplete() && !file.error"><?= htmlspecialchars($l->t('Completed')); ?></span>
       </td>
     </tr>
     </tbody>

--- a/templates/main.php
+++ b/templates/main.php
@@ -16,6 +16,7 @@
     <a class="btn btn-small btn-success" ng-click="$flow.resume()"><?= $l->t('Upload/Resume all'); ?></a>
     <a class="btn btn-small btn-danger" ng-click="$flow.pause()"><?= $l->t('Pause'); ?></a>
     <a class="btn btn-small btn-info" ng-click="$flow.cancel()"><?= $l->t('Cancel'); ?></a>
+    <a class="btn btn-small btn-info" ng-click="hideFinished = !hideFinished"><input style="min-height: unset; vertical-align: middle;" type="checkbox" ng-model="hideFinished"></input><span><?= $l->t('Hide finished uploads'); ?></span></a>
     <span class="label label-info"><?= $l->t('Size'); ?>: {{$flow.getSize() | bytes}}</span>
     <span class="label label-info" ng-if="$flow.getFilesCount() != 0"><?= $l->t('Progress'); ?>: {{$flow.progress()*100 | number:2}}%</span>
     <span class="label label-info" ng-if="$flow.isUploading()"><?= $l->t('Uploading'); ?>...</span>
@@ -44,7 +45,7 @@
     </tr>
     </thead>
     <tbody>
-    <tr ng-repeat="file in transfers | orderBy:sortType:sortReverse">
+    <tr ng-if="!(file.isComplete() && hideFinished)" ng-repeat="file in transfers | orderBy:sortType:sortReverse">
       <td>{{$index+1}}</td>
       <td title="UID: {{file.uniqueIdentifier}}">{{file.relativePath}}</td>
       <td title="Chunks: {{file.completeChunks()}} / {{file.chunks.length}}"><span ng-if="file.isUploading()">{{file.size*file.progress() | bytes}}/</span>{{file.size | bytes}}</td>


### PR DESCRIPTION
I personally often use flowupload to upload thousands of small files and i think its really annoying to scroll far down to see wich files are currently being uploaded.
In combination with the Sorting feature its now possible to always see the files , that are currently being uploaded, on the top of the page (sort by greatest progress).
On uploads with many files this can possibly also improve performance because there are less HTML elements.

![image](https://user-images.githubusercontent.com/28999431/67129514-30d91b80-f1ff-11e9-8cef-aea79c03c3b8.png)
