### PR TITLE
Progressbar fix

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -14,3 +14,15 @@
 #hideFinishedText {
   vertical-align: middle;
 }
+.progressColumnDiv {
+    display: flex;
+    align-items: center;
+}
+.progressColumnDiv * {
+    margin-left: 7px;
+    margin-right: 7px;
+}
+.progressbar {
+    height: 20px;
+    max-width: 40%;
+}

--- a/templates/main.php
+++ b/templates/main.php
@@ -53,8 +53,8 @@
       <td title="UID: {{file.uniqueIdentifier}}">{{file.relativePath}}</td>
       <td title="Chunks: {{file.completeChunks()}} / {{file.chunks.length}}"><span ng-if="file.isUploading()">{{file.size*file.progress() | bytes}}/</span>{{file.size | bytes}}</td>
       <td>
-        <div class="btn-group" ng-if="!file.isComplete() || file.error">
-          <progress max="1" value="{{file.progress()}}" title="{{file.progress()}}" style="width:auto; height:auto; display:inline;"></progress>
+        <div class="progressColumnDiv btn-group" ng-if="!file.isComplete() || file.error">
+          <progress class="progressbar" max="1" value="{{file.progress()}}" title="{{file.progress()}}"></progress>
           <a class="btn btn-mini btn-warning" ng-click="file.pause()" ng-hide="file.paused">
             <?= htmlspecialchars($l->t('Pause')); ?>
           </a>

--- a/templates/main.php
+++ b/templates/main.php
@@ -54,7 +54,7 @@
       <td title="Chunks: {{file.completeChunks()}} / {{file.chunks.length}}"><span ng-if="file.isUploading()">{{file.size*file.progress() | bytes}}/</span>{{file.size | bytes}}</td>
       <td>
         <div class="btn-group" ng-if="!file.isComplete() || file.error">
-          <progress max="1" value="{{file.progress()}}" title="{{file.progress()}}" ng-if="file.isUploading()" style="width:auto; height:auto; display:inline;"></progress>
+          <progress max="1" value="{{file.progress()}}" title="{{file.progress()}}" style="width:auto; height:auto; display:inline;"></progress>
           <a class="btn btn-mini btn-warning" ng-click="file.pause()" ng-hide="file.paused">
             <?= htmlspecialchars($l->t('Pause')); ?>
           </a>


### PR DESCRIPTION
The current Progressbar Styling doesn't seem to work correctly in the newest Versions of Chromium based Browsers.
## Before:
(latest Release on Nextcloud App Store)
### Firefox:
<img width="1384" alt="firefox_latest_release" src="https://user-images.githubusercontent.com/28999431/67420575-2a67ec80-f5cf-11e9-95e1-54874016cfcc.png">

### Chrome
<img width="1478" alt="chrome_newest_release" src="https://user-images.githubusercontent.com/28999431/67420592-36ec4500-f5cf-11e9-94eb-38c4b392724c.png">


## This PR:
### Firefox
<img width="1382" alt="firefox_after_change" src="https://user-images.githubusercontent.com/28999431/67420655-5a16f480-f5cf-11e9-8b03-cd65b0cff0ae.png">

### Chrome
<img width="1474" alt="chrome_after_change" src="https://user-images.githubusercontent.com/28999431/67420689-656a2000-f5cf-11e9-91ab-c1b98613bf29.png">


-> Now it works consistently across Firefox and Chrome

Also now the Progressbar doesn't get hidden when the Upload is paused.
I think thats better because then the Pause and Cancel Buttons don't move when paused.
Is that better or should i undo that ?

In Edge and Internet Explorer there is still a litte design problem, but I will fix it in the next Commit.