### PR TITLE
Remove home directory link

### DIFF
--- a/css/style.scss
+++ b/css/style.scss
@@ -11,10 +11,6 @@
 	margin-bottom: 25px;
 }
 
-#homeDirectoryLink {
-	margin-top: 25px;
-}
-
 #hideFinishedButton>input {
 	min-height: unset;
 	vertical-align: middle;

--- a/src/App.vue
+++ b/src/App.vue
@@ -159,7 +159,6 @@
 							</tr>
 						</tbody>
 					</table>
-					<p id="homeDirectoryLink"><a href="../files?dir=%2Fflowupload">{{ t('flowupload', 'The files will be saved in your home directory.') }}</a></p>
 				</div>
 			</div>
 		</AppContent>


### PR DESCRIPTION
This is just a small detail i forgot in my PR. Since you can open the selected location in the files app a link to the users home directory isn't necessary anymore.